### PR TITLE
Load Stipple app directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [0.3.0]
+
+### Updated
+- Increased compat bound for PromptingTools to 0.43
+
+### Fixed
+- Changed Stipple App loading strategy to prevent issues with temporary environments
+
 ## [0.2.1]
 
 ### Updated

--- a/Project.toml
+++ b/Project.toml
@@ -1,26 +1,30 @@
 name = "Spehulak"
 uuid = "13b2040c-5979-4bcf-93a6-c2323bf411ba"
 authors = ["J S <49557684+svilupp@users.noreply.github.com> and contributors"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 GenieFramework = "a59fdf5c-6bf0-4f5d-949c-a137c9e2f353"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 PromptingTools = "670122d1-24a8-4d70-bfce-740807c42192"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StippleDownloads = "291a174b-6542-42e7-9996-fc00d7c03310"
 
 [compat]
 Aqua = "0.7"
+Base64 = "<0.0.1, 1"
 CSV = "0.10"
 DataFrames = "1.4,1.5,1.6"
 Dates = "<0.0.1, 1"
 GenieFramework = "2.1"
 JSON3 = "1"
-PromptingTools = "0.36 - 0.42"
+PromptingTools = "0.36 - 0.43"
+Random = "<0.0.1, 1"
 Statistics = "<0.0.1, 1"
 StippleDownloads = "0.1"
 Test = "<0.0.1, 1"

--- a/src/server.jl
+++ b/src/server.jl
@@ -16,6 +16,9 @@ This is a convenience wrapper around `Genie.up`, to customize the server configu
 function launch(
         port::Int = 9001, host::String = "127.0.0.1";
         async::Bool = true)
-    Genie.loadapp(pkgdir(Spehulak))
-    up(port, host; async)
+    # disabled - wasn't working robustly
+    # Genie.loadapp(pkgdir(Spehulak))
+    ## Load the module explicitly
+    include(joinpath(pkgdir(Spehulak), "app.jl"))
+    App.up(port, host; async)
 end


### PR DESCRIPTION
- Changed Stipple App loading strategy to prevent issues with temporary environments
- Increased compat bound for PromptingTools to 0.43

